### PR TITLE
Fixes #3 - Check for domains, and if set in Umbraco, use contentid prefix in GetByRoute call

### DIFF
--- a/PageNotFoundManager/PageNotFoundContentFinder.cs
+++ b/PageNotFoundManager/PageNotFoundContentFinder.cs
@@ -16,11 +16,29 @@ namespace PageNotFoundManager
         {
             
             var uri = contentRequest.Uri.GetAbsolutePathDecoded();
-            var closestContent = UmbracoContext.Current.ContentCache.GetByRoute(uri.ToString());
+      // a route is "/path/to/page" when there is no domain, and "123/path/to/page" when there is a domain, and then 123 is the ID of the node which is the root of the domain
+           //get domain name from Uri
+            // find umbraco home node for uri's domain, and get the id of the node it is set on
+            var ds = ApplicationContext.Current.Services.DomainService;
+            var domains = ds.GetAll(true) as IList<IDomain> ?? ds.GetAll(true).ToList();
+            var domainRoutePrefixId = String.Empty;
+            if (domains.Any())
+            {
+                // a domain is set, so I think we need to prefix the request to GetByRoute by the id of the node it is attached to.
+                // I guess if the Uri contains one of these, lets use it's RootContentid as a prefix for the subsequent calls to GetByRoute...
+                var domain = domains.FirstOrDefault(d => (contentRequest.Uri.Authority.ToLower() + contentRequest.Uri.AbsolutePath.ToLower())
+                                .StartsWith(d.DomainName.ToLower()));
+                if (domain != null)
+                {
+                    // the domain has a RootContentId that we can use as the prefix.
+                    domainRoutePrefixId = domain.RootContentId.ToString();
+                }
+            }
+            var closestContent = UmbracoContext.Current.ContentCache.GetByRoute(domainRoutePrefixId + uri.ToString(),false);
             while (closestContent == null)
             {
                 uri = uri.Remove(uri.Length - 1, 1);
-                closestContent = UmbracoContext.Current.ContentCache.GetByRoute(uri.ToString());
+                closestContent = UmbracoContext.Current.ContentCache.GetByRoute(domainRoutePrefixId + uri.ToString(), false);
             }
             var nfp = Config.GetNotFoundPage(closestContent.Id);
 


### PR DESCRIPTION
Not sure if this is the best fix, but hopefully gives a gist of why it doesn't work if a domain is set.