### PR TITLE
Adding uninstall support for PNFM.TransformConfig package action

### DIFF
--- a/BuildPackages/Package.xml
+++ b/BuildPackages/Package.xml
@@ -29,7 +29,7 @@
 	<Languages />
 	<DataTypes />
     	<Actions>
-    		<Action runat="install" undo="false" alias="PNFM.TransformConfig" file="~/web.config" xdtfile="~/app_plugins/PageNotFoundManager/temp/web.config.install.xdt"></Action>
+    		<Action runat="install" undo="false" alias="PNFM.TransformConfig" file="~/web.config" xdtfile="~/app_plugins/PageNotFoundManager/temp/web.config"></Action>
     	</Actions>
 	<control />
 	<files />

--- a/PageNotFoundManager.sln
+++ b/PageNotFoundManager.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+VisualStudioVersion = 12.0.40629.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PageNotFoundManager", "PageNotFoundManager\PageNotFoundManager.csproj", "{2F1494AC-E9FA-463D-8658-1E66D40B6E97}"
 EndProject
@@ -12,6 +12,15 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{2E0D3F
 		.nuget\NuGet.Config = .nuget\NuGet.Config
 		.nuget\NuGet.exe = .nuget\NuGet.exe
 		.nuget\NuGet.targets = .nuget\NuGet.targets
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "BuildPackage", "BuildPackage", "{35134CA1-6396-4AA8-AD4F-D38319C79B54}"
+	ProjectSection(SolutionItems) = preProject
+		appveyor.yml = appveyor.yml
+		BuildPackages\package.nuspec = BuildPackages\package.nuspec
+		BuildPackages\Package.xml = BuildPackages\Package.xml
+		Readme.md = Readme.md
+		BuildPackages\web.config.install.xdt = BuildPackages\web.config.install.xdt
 	EndProjectSection
 EndProject
 Global

--- a/PageNotFoundManager/Umbraco/Installer/PackageActions.cs
+++ b/PageNotFoundManager/Umbraco/Installer/PackageActions.cs
@@ -10,26 +10,31 @@ namespace PageNotFoundManager.Umbraco.Installer
 {
     public class PackageActions
     {
-        public class TransformConfig: IPackageAction
+        public class TransformConfig : IPackageAction
         {
-
             public string Alias()
             {
                 return "PNFM.TransformConfig";
             }
 
-            public bool Execute(string packageName, System.Xml.XmlNode xmlData)
+            private bool Transform(string packageName, System.Xml.XmlNode xmlData, bool uninstall = false)
             {
-                
-
                 //The config file we want to modify
                 var file = xmlData.Attributes.GetNamedItem("file").Value;
+
                 string sourceDocFileName = VirtualPathUtility.ToAbsolute(file);
-                
+
                 //The xdt file used for tranformation 
-                var xdtfile = xmlData.Attributes.GetNamedItem("xdtfile").Value;
+                //var xdtfile = xmlData.Attributes.GetNamedItem("xdtfile").Value;
+                var fileEnd = "install.xdt";
+                if (uninstall)
+                {
+                    fileEnd = string.Format("un{0}", fileEnd);
+                }
+
+                var xdtfile = string.Format("{0}.{1}", xmlData.Attributes.GetNamedItem("xdtfile").Value, fileEnd);
                 string xdtFileName = VirtualPathUtility.ToAbsolute(xdtfile);
-                
+
                 // The translation at-hand
                 using (var xmlDoc = new XmlTransformableDocument())
                 {
@@ -47,20 +52,24 @@ namespace PageNotFoundManager.Umbraco.Installer
                         }
                     }
                 }
-
                 return true;
+            }
+
+            public bool Execute(string packageName, System.Xml.XmlNode xmlData)
+            {
+                return Transform(packageName, xmlData);
             }
 
             public System.Xml.XmlNode SampleXml()
             {
-                string str = "<Action runat=\"install\" undo=\"false\" alias=\"PNFM.TransformConfig\" file=\"~/web.config\" xdtfile=\"~/app_plugins/demo/web.config.xdt\">" +
+                string str = "<Action runat=\"install\" undo=\"true\" alias=\"PNFM.TransformConfig\" file=\"~/web.config\" xdtfile=\"~/app_plugins/demo/web.config\">" +
                          "</Action>";
                 return helper.parseStringToXmlNode(str);
             }
 
             public bool Undo(string packageName, System.Xml.XmlNode xmlData)
             {
-                return false;
+                return Transform(packageName, xmlData, true);
             }
         }
     }


### PR DESCRIPTION
In needed this for another package so thought I would send back to you.

Adding uninstall support for PNFM.TransformConfig package action even though it's not needed on this package it's useful for others!
Note the change to the xdtfile parameter in package.xml, it now doesn't include the ending .install.xdt (or uninstall.xdt)

p.s. this package action is awesome!